### PR TITLE
Update core.js for deduplication of PST timezone entry

### DIFF
--- a/core.js
+++ b/core.js
@@ -147,7 +147,6 @@ var utc_offsets = {
     "PMST": "-03",
     "PONT": "+11",
     "PST": "-08",
-    "PST": "+08",
     "PYST": "-03",
     "PYT": "-04",
     "RET": "+04",


### PR DESCRIPTION
PST had 2 entries,  -08 and +08 resulting wrong local time conversion.